### PR TITLE
Expose client after plugin initialisation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 
 node_js:
-  - "4"
-  - "5"
   - "6"
   - "7"
+  - "8"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ oc-statsd [![Build Status](https://secure.travis-ci.org/opencomponents/oc-statsd
 
 # Requirements:
 
-* Node version: min: **4**
+* Node version: min: **6**
 * OC registry
 * StatsD server
 
@@ -77,7 +77,7 @@ module.exports.data = (context, callback) => {
 |port|`number`|no|Default 8152, the statsd port|
 |prefix|`string`|yes|The statsd prefix|
 
-#### Api for plugin usage:
+#### Api for plugin usage
 
 The plugin name is declared when initialising a plugin. Following assumes `statsd` is the designated name.
 

--- a/index.js
+++ b/index.js
@@ -1,19 +1,24 @@
 'use strict';
 
-var StatsDClient = require('statsd-client');
+const StatsDClient = require('statsd-client');
 
-var WHITESPACE_REGEX    = /\s+/g,
-    FORWARD_SLASH_REGEX = /\//g,
-    UNCLEAN_REGEX       = /[^a-zA-Z_\-0-9\.]/g;
+const WHITESPACE_REGEX    = /\s+/g;
+const FORWARD_SLASH_REGEX = /\//g;
+const UNCLEAN_REGEX       = /[^a-zA-Z_\-0-9\.]/g;
 
 
-StatsDClient.prototype.sanitize = function(key) {
-  return key.replace(WHITESPACE_REGEX, '_')
-    .replace(FORWARD_SLASH_REGEX, '-')
-    .replace(UNCLEAN_REGEX, '');
+StatsDClient.prototype.sanitize = (key) => key
+  .replace(WHITESPACE_REGEX, '_')
+  .replace(FORWARD_SLASH_REGEX, '-')
+  .replace(UNCLEAN_REGEX, '');
+
+let statsDClient;
+
+const getClient = (namespace) => {
+  const prefix = namespace || '';
+  return statsDClient.getChildClient(statsDClient.sanitize(prefix));
 };
 
-var statsDClient;
 /**
  * Register statsD client
  * @param {Object}  options - statsd client options
@@ -24,16 +29,13 @@ var statsDClient;
  * @param {boolean} [options.debug] - debug mode
  * @param {function} next - The callback that handles next.
  */
-module.exports.register = function(options, dependencies, next) {
+module.exports.register = (options, dependencies, next) => {
   statsDClient = new StatsDClient(options);
-  next();
+  next(null, { client: getClient });
 };
 
 /**
  * Get instance of statsd client in the supplied namespace
  * @param {string} [namespace=] - the namespace of the returned client
  */
-module.exports.execute = function(namespace) {
-  var prefix = namespace || '';
-  return statsDClient.getChildClient(statsDClient.sanitize(prefix));
-};
+module.exports.execute = getClient;

--- a/test/unit.js
+++ b/test/unit.js
@@ -1,109 +1,122 @@
 'use strict';
 
 var expect = require('chai').expect;
-
 var statsdPlugin = require('../index');
 
-var initialise = function(config, done) {
+var initialise = (config, done) => {
   statsdPlugin.register(config, {}, done);
 };
 
-describe('oc-statsd', function() {
+describe('oc-statsd', () => {
 
-  describe('when requesting a statsd client without namespace', function() {
+  describe('when initialised', () => {
+
+    let result;
+    before((done) => {
+      initialise({
+        debug: true,
+        prefix: 'test.client'
+      }, (err, details) => {
+        result = details.client;
+        done();
+      });
+    });
+
+    it('should return the initialised client', () => {
+      expect(result('my.stat').timing).to.be.a('function');
+    });
+  });
+
+  describe('when requesting a statsd client without namespace', () => {
 
     var result;
-    before(function(done) {
-      initialise({debug: true, prefix: 'test.client'}, function() {
+    before((done) => {
+      initialise({debug: true, prefix: 'test.client'}, () => {
         result = statsdPlugin.execute();
         done();
       });
     });
 
-    it('should return a statsd client', function() {
+    it('should return a statsd client', () => {
       expect(result).to.not.be.null;
     });
 
-    it('should return a statsd client with root namespace', function() {
+    it('should return a statsd client with root namespace', () => {
       expect(result.options.prefix).to.equal('test.client.');
     });
-
   });
 
-  describe('when requesting a statsd client with namespace', function() {
+  describe('when requesting a statsd client with namespace', () => {
 
     var result;
-    before(function(done) {
-      initialise({debug: true, prefix: 'test.client'}, function() {
+    before((done) => {
+      initialise({debug: true, prefix: 'test.client'}, () => {
         result = statsdPlugin.execute('new.prefix');
         done();
       });
     });
 
-    it('should return a statsd client', function() {
+    it('should return a statsd client', () => {
       expect(result).to.not.be.null;
     });
 
-    it('should return a statsd client with root namespace', function() {
+    it('should return a statsd client with root namespace', () => {
       expect(result.options.prefix).to.equal('test.client.new.prefix.');
     });
-
   });
 
-  describe('when requesting a statsd client to host', function() {
+  describe('when requesting a statsd client to host', () => {
 
     var result;
-    before(function(done) {
-      initialise({host: 'statsd.host.local', debug: true, prefix: 'test.client'}, function() {
+    before((done) => {
+      initialise({host: 'statsd.host.local', debug: true, prefix: 'test.client'}, () => {
         result = statsdPlugin.execute('new.prefix');
         done();
       });
     });
 
-    it('should return a statsd client', function() {
+    it('should return a statsd client', () => {
       expect(result).to.not.be.null;
     });
 
-    it('should return a statd client with host', function() {
+    it('should return a statd client with host', () => {
       expect(result._socket._hostname).to.equal('statsd.host.local');
     });
 
-    it('should return a statd client with default port', function() {
+    it('should return a statd client with default port', () => {
       expect(result._socket._port).to.equal(8125);
     });
-
   });
 
-  describe('when requesting a statsd client with sanitize', function() {
+  describe('when requesting a statsd client with sanitize', () => {
 
     var result;
-    before(function(done) {
-      initialise({host: 'statsd.host.local', debug: true, prefix: 'test.client'}, function() {
+    before((done) => {
+      initialise({host: 'statsd.host.local', debug: true, prefix: 'test.client'}, () => {
         result = statsdPlugin.execute('new.prefix');
         done();
       });
     });
 
-    it('should return a statsd client', function() {
+    it('should return a statsd client', () => {
       expect(result).to.not.be.null;
     });
 
-    it('should return a statd client with sanitize function', function() {
+    it('should return a statd client with sanitize function', () => {
       expect(result.sanitize).is.a('function');
     });
 
 
-    it('sanitize should replace space with underscore', function() {
+    it('sanitize should replace space with underscore', () => {
       expect(result.sanitize('  ')).to.equal('_');
     });
 
-    it('sanitize should replace forward slash with dash', function() {
+    it('sanitize should replace forward slash with dash', () => {
       expect(result.sanitize('/')).to.equal('-');
     });
 
-    it('sanitize should remove everything else ', function() {
+    it('sanitize should remove everything else ', () => {
       expect(result.sanitize('§$')).to.equal('');
     });
   });
-
 });


### PR DESCRIPTION
So that the initialised instance can be used for other arbitrary operations inside the registry app (for instance for pushing more data related to events being emitted)